### PR TITLE
[POC] Implement a proxy endpoint for blog post cover images to not need to move them out of Notion

### DIFF
--- a/lib/notionClient.ts
+++ b/lib/notionClient.ts
@@ -59,7 +59,7 @@ function transformNotionPageIntoBlogPost(
     title: getTitleValue(page.properties[PROPERTY_NAME]),
     originalNotionImageSrc: cover,
     imageSrc: cover
-      ? `${publicRuntimeConfig.SITE_URL}/notion-resources/pages/${page.id}/cover`
+      ? `https://${publicRuntimeConfig.VERCEL_URL}/notion-resources/pages/${page.id}/cover`
       : null,
   };
 }

--- a/lib/notionClient.ts
+++ b/lib/notionClient.ts
@@ -7,6 +7,8 @@ import getConfig from "next/config";
 import { BlogPost } from "../types/types";
 import probeImageSize from "./probeImageSize";
 
+const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
+
 // These are custom properties defined in the Notion database, that we use here to filter, sort, and show info
 const PROPERTY_SLUG = "Slug";
 const PROPERTY_EXCERPT = "Excerpt";
@@ -46,6 +48,7 @@ function transformNotionPageIntoBlogPost(
   if (!("properties" in page)) {
     return null;
   }
+  const cover = getCover(page);
   return {
     id: page.id,
     slug: getTextValue(page.properties[PROPERTY_SLUG]),
@@ -54,11 +57,12 @@ function transformNotionPageIntoBlogPost(
     dateUpdated: getDateValue(page.properties[PROPERTY_DATE_UPDATED]) || null,
     tags: getMultiSelectValues(page.properties[PROPERTY_TAGS]),
     title: getTitleValue(page.properties[PROPERTY_NAME]),
-    imageSrc: getCover(page),
+    originalNotionImageSrc: cover,
+    imageSrc: cover
+      ? `${publicRuntimeConfig.SITE_URL}/notion-resources/pages/${page.id}/cover`
+      : null,
   };
 }
-
-const { serverRuntimeConfig } = getConfig();
 
 const notion = new Client({
   auth: serverRuntimeConfig.NOTION_TOKEN,
@@ -98,6 +102,14 @@ export async function fetchBlogPosts(): Promise<BlogPost[]> {
   const blogPosts = results.map(transformNotionPageIntoBlogPost);
 
   return blogPosts;
+}
+
+export async function fetchBlogPostByPageId(pageId: string) {
+  const result = await notion.pages.retrieve({
+    page_id: pageId,
+  });
+  const blogPost = transformNotionPageIntoBlogPost(result);
+  return blogPost;
 }
 
 export async function fetchBlogPostBySlug(

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@
 const nextConfig = {
   reactStrictMode: true,
   publicRuntimeConfig: {
+    VERCEL_URL: process.env.VERCEL_URL,
     SITE_URL: process.env.SITE_URL,
     UMAMI_WEBSITE_ID: process.env.UMAMI_WEBSITE_ID,
     FORMBOLD_CONTACT_FORM_ENDPOINT: process.env.FORMBOLD_CONTACT_FORM_ENDPOINT,

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,7 @@ const nextConfig = {
   },
   images: {
     domains: [
+      process.env.SITE_URL.replace(/:[0-9]+$/, "").replace(/^https?:\/\//, ""),
       "s3.us-west-2.amazonaws.com", // Notion images
       "res.cloudinary.com", // Images moved to Cloudinary
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,7 @@ const nextConfig = {
   images: {
     domains: [
       process.env.SITE_URL.replace(/:[0-9]+$/, "").replace(/^https?:\/\//, ""),
+      process.env.VERCEL_URL,
       "s3.us-west-2.amazonaws.com", // Notion images
       "res.cloudinary.com", // Images moved to Cloudinary
     ],

--- a/pages/notion-resources/pages/[pageId]/cover.tsx
+++ b/pages/notion-resources/pages/[pageId]/cover.tsx
@@ -1,0 +1,118 @@
+/**
+ * This endpoint returns the cover image corresponding to the Notion page ID passed
+ * The Notion page needs to be part of the Notion database that was made accessible for the integration
+ *
+ * We use this technique to proxy images from Notion, as it returns URLs that expire in the API
+ * but for Next.js image optimization we need a stable endpoint. This is the stable endpoint, as it's cached
+ *
+ * TODO:
+ * - Make this statically generated on build time and revalidation, to not depend on Notion's state when the Vercel Edge Network cache expires
+ */
+
+import { GetServerSideProps } from "next";
+import { fetchBlogPostByPageId } from "../../../../lib/notionClient";
+
+function getContentTypeByExtension(url: string) {
+  const extensionToMimeType = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".apng": "image/apng",
+    ".avif": "image/avif",
+    ".tiff": "image/tiff",
+    ".svg": "image/svg+xml",
+  };
+  for (const [extension, mimeType] of Object.entries(extensionToMimeType)) {
+    if (url.endsWith(extension)) {
+      return mimeType;
+    }
+  }
+  return undefined;
+}
+
+const cacheMaxAge = 1209600; // 14 days (max supported is 31 days)
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const pageId = ctx.params.pageId;
+  if (!pageId || typeof pageId !== "string") {
+    ctx.res.statusCode = 400;
+    ctx.res.setHeader("Content-Type", "application/json");
+    ctx.res.write(
+      JSON.stringify({
+        error: "A valid pageId string is required",
+      })
+    );
+    ctx.res.end();
+    return { props: {} };
+  }
+
+  const { originalNotionImageSrc } = await fetchBlogPostByPageId(pageId);
+
+  if (!originalNotionImageSrc) {
+    ctx.res.statusCode = 400;
+    ctx.res.setHeader("Content-Type", "application/json");
+    ctx.res.write(
+      JSON.stringify({
+        error: "Not found",
+      })
+    );
+    ctx.res.end();
+    return { props: {} };
+  }
+
+  await fetch(originalNotionImageSrc, {
+    headers: {
+      accept:
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+      "accept-encoding": "gzip, deflate, br",
+      "cache-control": "max-age=0",
+    },
+  })
+    .then(async (imageResponse) => {
+      if (!imageResponse.ok) {
+        ctx.res.statusCode = imageResponse.status;
+        ctx.res.setHeader("Content-Type", "application/json");
+        ctx.res.write(
+          JSON.stringify({
+            error: `Download error: ${imageResponse.statusText}`,
+          })
+        );
+        ctx.res.end();
+        return;
+      }
+
+      const contentType =
+        imageResponse.headers.get("content-type") ||
+        getContentTypeByExtension(originalNotionImageSrc);
+      const contentLength = imageResponse.headers.get("content-length");
+
+      ctx.res.writeHead(200, {
+        "content-type": contentType,
+        "content-length": contentLength,
+        "cache-control": `public, max-age=${cacheMaxAge}`,
+      });
+      const readableStream =
+        imageResponse.body as unknown as NodeJS.ReadableStream;
+
+      await new Promise(function (resolve) {
+        readableStream.pipe(ctx.res);
+        readableStream.on("end", resolve);
+      });
+    })
+    .catch((error: Error) => {
+      console.error(error);
+      ctx.res.statusCode = 500;
+      ctx.res.setHeader("Content-Type", "application/json");
+      ctx.res.write(
+        JSON.stringify({
+          error: `${error.name}: ${error.message}`,
+        })
+      );
+      ctx.res.end();
+    });
+
+  return { props: {} };
+};
+
+// Default export to prevent next.js errors
+export default function NotionResourcePageCover() {}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -6,6 +6,7 @@ export type BlogPost = {
   datePublished: string;
   dateUpdated: string | null;
   tags: string[];
+  originalNotionImageSrc: string | null;
   imageSrc: string | null;
 };
 


### PR DESCRIPTION
Proof of concept for changing image hosting strategy from [using a script to move Notion assets to Cloudinary](https://github.com/guillermodlpa/upload-notion-images-to-cloudinary) to adding a **proxy endpoint for Notion images that can cache them indefinitely**. Based on https://jake.tl/projects/notion-api#solving-image-hosting

Demo:

* Images in https://site-git-notion-resources-api-guillermodlpa.vercel.app/blog are loaded using a proxy endpoint, and then rendered with Next.js image optimization

To do:

- [ ] Make the proxy images statically generated on build time and revalidation, to not depend on Notion's state when the Vercel Edge Network cache expires ([note SSR caching has a limit of 31 days in Vercel](https://vercel.com/docs/concepts/edge-network/caching#limits))

Alternatives:

- There might be nothing more stable and robust than moving the images to a separate service, like Cloudinary. That way, images are persistent and we don't depend on a cache that could be reset at any time to avoid requests to Notion after the pages are generated.
